### PR TITLE
fix perl rcfile handling

### DIFF
--- a/distribution
+++ b/distribution
@@ -83,7 +83,7 @@ my $inLine;
 
 # if they want an rcfile, must be first arg
 my $rcFile = $ENV{"HOME"} . "/.distributionrc";
-if ($ARGV && $ARGV[0] =~ /^-+r(cfile)*=(.+)$/) { $rcFile = $2; }
+if (@ARGV && $ARGV[0] =~ /^-+r(cfile)*=(.+)$/) { $rcFile = $2; }
 
 # read in rcfile if it exists - it'll just be args
 if (open (IFILE, "< $rcFile")) {


### PR DESCRIPTION
I'm not a Perl expert, but it looks like `if ($ARGV)` is always false, whereas `if (@ARGV)` is true IFF ARGV has one or more elements. That was causing the Perl version to ignore the rcfile option in `runTests.sh`, so this gets closer to clean tests in #10 . Tested on OSX with Perl 5.18 and OpenBSD with Perl 5.20.