### PR TITLE
chomp newlines in python

### DIFF
--- a/distribution.py
+++ b/distribution.py
@@ -211,6 +211,7 @@ class InputReader(object):
 
 		pruneObjects = 0
 		for line in sys.stdin:
+			line = line.rstrip('\n')
 			if s.tokenize:
 				for token in pt.split(line):
 					# user desires to break line into tokens...
@@ -225,7 +226,6 @@ class InputReader(object):
 			else:
 				# user just wants every line to be a token
 				s.totalObjects += 1
-				line = line.rstrip()
 				if pm.match(line):
 					s.totalValues += 1
 					pruneObjects += 1


### PR DESCRIPTION
This bring the Python version's linebreak-chomping in line with the Perl version. Instead of only chomping in line-mode, we also chomp in token mode, and we only chomp newlines instead of any whitespace. This causes test 4 to pass, as it uses `--token=/` which causes the existing Python version to use token parsing mode, which brings in newlines into tokens, which is not what we want.

This was tested on both DOS and UNIX line-ending input files, which both work with '\n' because of Python's "universal newline support" introduced in PEP 278. Python versions used to test were 2.7.12 on OSX and 3.4.4 on OpenBSD.